### PR TITLE
Adding ability to set a version of the provider

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - arm64
     binary: registrygen
     main: ./main.go
+    ldflags: -X github.com/pulumi/registrygen/pkg/version.Version={{.Version}}
 archives:
   - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/registrygen/cmd/docs"
 	"github.com/pulumi/registrygen/cmd/metadata"
+	"github.com/pulumi/registrygen/cmd/version"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +34,7 @@ func RootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(docs.ResourceDocsCmd())
 	rootCmd.AddCommand(metadata.PackageMetadataCmd())
+	rootCmd.AddCommand(version.Command())
 
 	return rootCmd
 }

--- a/cmd/version/cli.go
+++ b/cmd/version/cli.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"fmt"
+
+	cliVersion "github.com/pulumi/registrygen/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "version",
+		Short: "Get the current version",
+		Long:  `Get the current version of pulumictl`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(cliVersion.Version)
+			return nil
+		},
+	}
+	return command
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the version of this tool.
+var Version string


### PR DESCRIPTION
Before:

```
registrygen version
Error: unknown command "version" for "registrygen"
Run 'registrygen --help' for usage.
E0126 19:02:42.318833   45359 main.go:31] Failed to execute command: unknown command "version" for "registrygen"
```

After:

```
▶ ./dist/registrygen_darwin_amd64/registrygen version
10.0.0-SNAPSHOT
```