### PR TITLE
Adding the ability to pass the providerName arg for default schemaFilePath construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Go 1.16
+      - name: Install Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.x'
+          go-version: 1.17.x
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone
         run: git fetch --prune --unshallow
-      - name: Install Go 1.16
+      - name: Install Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.x'
+          go-version: 1.17.x
       - name: Goreleaser publish
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
Without being able to pass a providerName, the user must specify the schemaFile
but 99% of our schemaFiles are in a standard location therefore we can make
this optional. 

I thought about trying to pull the provider name out of the repoSlug but there
are no guarantees that the repo name relates to the providerName

So the user can now pass schemaFile or pass providerName and we can find the
correct schemaFile
﻿
