### PR TITLE
Add Version Check for third-party providers

### DIFF
--- a/cmd/metadata/metadata.go
+++ b/cmd/metadata/metadata.go
@@ -246,7 +246,7 @@ func PackageMetadataCmd() *cobra.Command {
 	cmd.Flags().StringVar(&providerName, "providerName", "", "The name of the provider e.g. aws, aws-native. "+
 		"Required when there is no schemaFile flag specified.")
 	cmd.Flags().StringVarP(&schemaFile, "schemaFile", "s", "", "Relative path to the schema.json file from "+
-		"the root of the repository. If not schemaFile is specified, then providerName is required so the schemaFile path can "+
+		"the root of the repository. If no schemaFile is specified, then providerName is required so the schemaFile path can "+
 		"be inferred to be provider/cmd/pulumi-resource-<providerName>/schema.json")
 	cmd.Flags().StringVar(&version, "version", "", "The version of the package")
 	cmd.Flags().StringVar(&categoryStr, "category", "", fmt.Sprintf("The category for the package. Value must "+

--- a/cmd/pkgversion/pkgversion.go
+++ b/cmd/pkgversion/pkgversion.go
@@ -1,0 +1,29 @@
+package pkgversion
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func CheckVersion() *cobra.Command {
+
+	var repoSlug string
+	var schemaFile string
+	cmd := &cobra.Command{
+		Use:   "pkgversion",
+		Short: "Check a Pulumi package version",
+		Long:  `Get the most recent version of a Pulumi package on the registry`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("Checking the correct version on github")
+			fmt.Println(repoSlug)
+			fmt.Println(schemaFile)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&repoSlug, "repoSlug", "r", "", "The repository slug e.g. pulumi/pulumi-provider") //TODO: consider the name and if we need full link here
+	cmd.Flags().StringVarP(&schemaFile, "schemaFile", "s", "", "Relative path to the schema.json file from "+
+		"the root of the repository.")
+	cmd.MarkFlagRequired("schemaFile")
+	cmd.MarkFlagRequired("repoSlug")
+	return cmd
+}

--- a/cmd/pkgversion/pkgversion.go
+++ b/cmd/pkgversion/pkgversion.go
@@ -1,29 +1,91 @@
 package pkgversion
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
+	"github.com/pulumi/registrygen/pkg"
 	"github.com/spf13/cobra"
+	"net/http"
+	"strings"
 )
 
 func CheckVersion() *cobra.Command {
 
-	var repoSlug string
-	var schemaFile string
+	var owner string
+	var repo string
 	cmd := &cobra.Command{
 		Use:   "pkgversion",
 		Short: "Check a Pulumi package version",
 		Long:  `Get the most recent version of a Pulumi package on the registry`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Checking the correct version on github")
-			fmt.Println(repoSlug)
-			fmt.Println(schemaFile)
+			fmt.Println(owner)
+			latest := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+			version, err := getLatestVersion(latest)
+			if err != nil {
+				return err
+			}
+			pkgName := strings.TrimPrefix(repo, "pulumi-")
+			fmt.Println(pkgName)
+			pkgMetadata := fmt.Sprintf("https://raw.githubusercontent.com/pulumi/registry/themes/default/data/registry/packages/%s", pkgName)
+			regVersion, err := getRegistryVersion(pkgMetadata)
+			if err != nil {
+				return err
+			}
+			fmt.Println("Latest version: ", version)
+			fmt.Println("Registry version: ", regVersion)
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&repoSlug, "repoSlug", "r", "", "The repository slug e.g. pulumi/pulumi-provider") //TODO: consider the name and if we need full link here
-	cmd.Flags().StringVarP(&schemaFile, "schemaFile", "s", "", "Relative path to the schema.json file from "+
-		"the root of the repository.")
-	cmd.MarkFlagRequired("schemaFile")
-	cmd.MarkFlagRequired("repoSlug")
+
+	cmd.Flags().StringVarP(&owner, "owner", "o", "", "The github owner or organization, e.g. pulumi")
+
+	cmd.Flags().StringVarP(&repo, "repo", "r", "", "The github repo for this package, e.g. pulumi-aws")
+	cmd.MarkFlagRequired("owner")
+	cmd.MarkFlagRequired("repo")
 	return cmd
+}
+
+func getLatestVersion(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("getting latest version from %s", url))
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", errors.Wrap(err, fmt.Sprintf("Could not find a release at %s", url))
+	}
+
+	var tag pkg.GitHubTag
+	err = json.NewDecoder(resp.Body).Decode(&tag)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failure reading contents of latest tag")
+	}
+
+	return tag.Name, nil
+}
+
+func getRegistryVersion(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("getting latest version from %s", url))
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// this checks that the file exists and has content
+		return "", errors.Wrap(err, "this package has no metadata file yet")
+	}
+
+	var meta pkg.PackageMeta
+	err = json.NewDecoder(resp.Body).Decode(&meta)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failure reading contents of remote file")
+	}
+
+	return meta.Version, nil
 }

--- a/cmd/pkgversion/pkgversion.go
+++ b/cmd/pkgversion/pkgversion.go
@@ -34,10 +34,9 @@ func CheckVersion() *cobra.Command {
 				return err
 			}
 
-			// emit version tag if there's a difference, and not if there isn't
+			// print version tag if there's a difference, and not if there isn't
 			// we assume that the published latest version from the provider repo is the desired one, so any difference
 			// between versions should indicate an update to the registry version
-			// TODO: start with a print output but may have to write to a file
 			if version != regVersion {
 				fmt.Println(version)
 			}

--- a/cmd/pkgversion/pkgversion.go
+++ b/cmd/pkgversion/pkgversion.go
@@ -22,23 +22,25 @@ func CheckVersion() *cobra.Command {
 		Short: "Check a Pulumi package version",
 		Long:  `Get the most recent version of a Pulumi package and compare with the version in the registry`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("Checking the correct version on github")
-			fmt.Println(owner)
 			latest := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
 			version, err := getLatestVersion(latest)
 			if err != nil {
 				return err
 			}
 			pkgName := strings.TrimPrefix(repo, "pulumi-")
-			fmt.Println(pkgName)
 			pkgMetadata := fmt.Sprintf("https://raw.githubusercontent.com/pulumi/registry/master/themes/default/data/registry/packages/%s.yaml", pkgName)
 			regVersion, err := getRegistryVersion(pkgMetadata)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Latest version:", version)
-			fmt.Println("Registry version:", regVersion)
+
 			// emit version tag if there's a difference, and not if there isn't
+			// we assume that the published latest version from the provider repo is the desired one, so any difference
+			// between versions should indicate an update to the registry version
+			// TODO: start with a print output but may have to write to a file
+			if version != regVersion {
+				fmt.Println(version)
+			}
 			return nil
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/pulumi/registrygen/cmd/docs"
 	"github.com/pulumi/registrygen/cmd/metadata"
+	"github.com/pulumi/registrygen/cmd/pkgversion"
 	"github.com/pulumi/registrygen/cmd/version"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(metadata.PackageMetadataCmd())
 	rootCmd.AddCommand(version.Command())
 	rootCmd.AddCommand(docs.GenerateCommand())
+	rootCmd.AddCommand(pkgversion.CheckVersion())
 
 	return rootCmd
 }


### PR DESCRIPTION
Create pkgversion command to verify an upstream version change. The command requires an `owner` and a `repo` input and will query both the package version as listed on their latest release, as well as check the metadata file in `pulumi/registry`.

The command will print an updated release version if there's a version difference between the latest release and the registry version. It will print nothing if they're the same.

This is a very basic, no-frills functionality and I'm almost certain we'll need to expand on it.

I'm also happy to hear thoughts about naming this command differently.

Part of https://github.com/pulumi/registry/issues/853