### PR TITLE
Update release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 on:
   push:
-    tags: [ "v*.*.*" ] # only a valid semver tag
+    tags: ["v*.*.*"] # only a valid semver tag
 
 jobs:
   goreleaser:
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone
         run: git fetch --prune --unshallow
-      - name: Install Go 1.17
+      - name: Install Go 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
       - name: Goreleaser publish
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
registrygen doesn't build on 1.17 anymore due to issues with `github.com/Azure/azure-sdk-for-go/sdk/azcore`.