### PR TITLE
Use github token if it is available for api requests

### DIFF
--- a/cmd/metadata/metadata.go
+++ b/cmd/metadata/metadata.go
@@ -400,10 +400,8 @@ func getTagFromKeywords(keywords []string, tag string) *string {
 }
 
 func getGitHubTags(repoSlug string) ([]pkg.GitHubTag, error) {
-	tagsUrl := fmt.Sprintf("https://api.github.com/repos/%s/tags", repoSlug)
-
-	var tags []pkg.GitHubTag
-	tagsResp, err := http.Get(tagsUrl)
+	path := fmt.Sprintf("/repos/%s/tags", repoSlug)
+	tagsResp, err := pkg.GetGitHubAPI(path)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("getting tags info for %s", repoSlug))
 	}
@@ -418,6 +416,7 @@ func getGitHubTags(repoSlug string) ([]pkg.GitHubTag, error) {
 		return nil, fmt.Errorf("getting tags info for %s: %s", repoSlug, string(respBody))
 	}
 
+	var tags []pkg.GitHubTag
 	err = json.NewDecoder(tagsResp.Body).Decode(&tags)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("constructing tags information for %s", repoSlug))

--- a/cmd/pkgversion/pkgversion.go
+++ b/cmd/pkgversion/pkgversion.go
@@ -3,6 +3,7 @@ package pkgversion
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/pulumi/registrygen/pkg"
@@ -33,8 +34,7 @@ func CheckVersion() *cobra.Command {
 				repoName = githubSlugParts[1]
 			}
 
-			latest := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repoSlug)
-			version, err := getLatestVersion(latest)
+			version, err := getLatestVersion(repoSlug)
 			if err != nil {
 				return err
 			}
@@ -61,15 +61,17 @@ func CheckVersion() *cobra.Command {
 	return cmd
 }
 
-func getLatestVersion(url string) (string, error) {
-	resp, err := http.Get(url)
+func getLatestVersion(repoSlug string) (string, error) {
+	path := fmt.Sprintf("/repos/%s/releases/latest", repoSlug)
+	resp, err := pkg.GetGitHubAPI(path)
+
 	if err != nil {
-		return "", errors.Wrap(err, fmt.Sprintf("getting latest version from %s", url))
+		return "", errors.Wrap(err, fmt.Sprintf("getting latest version from https://api.github.com%s", path))
 	}
 
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return "", errors.Wrap(err, fmt.Sprintf("Could not find a release at %s", url))
+		return "", errors.Wrap(err, fmt.Sprintf("Could not find a release at https://api.github.com%s", path))
 	}
 
 	var tag pkg.GitHubTag

--- a/pkg/githubInfo.go
+++ b/pkg/githubInfo.go
@@ -1,8 +1,34 @@
 package pkg
 
 import (
+	"fmt"
+	"net/http"
+	"os"
 	"time"
+
+	"github.com/pkg/errors"
 )
+
+func GetGitHubAPI(path string) (*http.Response, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	url := fmt.Sprintf("https://api.github.com%s", path)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating request")
+	}
+
+	req.Header = http.Header{
+		"Content-Type": {"application/json"},
+	}
+
+	if token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	return client.Do(req)
+}
 
 type GitHubTag struct {
 	Name       string `json:"name"`


### PR DESCRIPTION
We have seen some failures recently that we couldn't pin down due to vague error messages. In a recent PR we introduced some more logging and it revealed we are getting hit by GitHub Rate Limiting. This is due to not using the GITHUB_TOKEN when making requests to the GitHub API.

This PR adds logic to include the GITHUB_TOKEN to the request if it is available. This will increase of limit from 60 requests/hr to 1000 requests/hr based on the [GitHub Docs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions).