### PR TITLE
feat: Copy all files located beneath the docs folder

### DIFF
--- a/cmd/metadata/metadata.go
+++ b/cmd/metadata/metadata.go
@@ -246,15 +246,6 @@ func PackageMetadataCmd() *cobra.Command {
 				"docs/installation-configuration.md",
 			}
 
-			/*
-				1. Load initial data for https://api.github.com/repos/<repoSlug>/contents/docs?ref=<version>
-				2. Add all files to an array
-				3. Check if all required (top-level) files are present
-				4. If any sub-directories are detected (type==dir)
-				   -> cursively coll the contents api using the url property and add the files to the result array
-				5. Download all files from the array using the "download_url" property
-			*/
-
 			files, err := pkg.GetGitHubFileContents(repoSlug, "docs", version)
 			if err != nil {
 				return err

--- a/cmd/metadata/metadata.go
+++ b/cmd/metadata/metadata.go
@@ -316,7 +316,11 @@ func PackageMetadataCmd() *cobra.Command {
 }
 
 func readRemoteFile(url string) ([]byte, error) {
-	resp, err := http.Get(url)
+	client, err := pkg.GetGitHubCLient()
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("downloading remote file from %s", url))
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("downloading remote file from %s", url))
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/gofri/go-github-ratelimit v1.0.4
 	github.com/golang/glog v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/pkg/v3 v3.53.0

--- a/go.sum
+++ b/go.sum
@@ -1192,6 +1192,8 @@ github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofri/go-github-ratelimit v1.0.4 h1:pOwtjHldpsDACBgBiyfa3exXbbu8hlQ9tgFPimnCZzM=
+github.com/gofri/go-github-ratelimit v1.0.4/go.mod h1:OnCi5gV+hAG/LMR7llGhU7yHt44se9sYgKPnafoL7RY=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=

--- a/pkg/githubInfo.go
+++ b/pkg/githubInfo.go
@@ -31,7 +31,6 @@ func GetGitHubCLient() (client *http.Client, err error) {
 }
 
 func GetGitHubAPI(path string) (*http.Response, error) {
-	token := os.Getenv("GITHUB_TOKEN")
 	if !strings.HasPrefix(path, "https://api.github.com") {
 		path = fmt.Sprintf("https://api.github.com%s", path)
 	}
@@ -49,7 +48,7 @@ func GetGitHubAPI(path string) (*http.Response, error) {
 		"Content-Type": {"application/json"},
 	}
 
-	if token != "" {
+	if token, ok := os.LookupEnv("GITHUB_TOKEN"); ok && token != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 

--- a/pkg/githubInfo.go
+++ b/pkg/githubInfo.go
@@ -90,7 +90,7 @@ func GetGitHubFileContents(repoSlug, repoPath, version string) (result *[]Reposi
 }
 
 func getGitHubFileContents(path string) (result *[]RepositoryContent, err error) {
-	rawJSON, err := GetGitHubAPI(path)
+	rawJSON, err := GetGitHubAPI(strings.TrimPrefix(path, "https://api.github.com"))
 	if err != nil {
 		err = errors.Wrap(err, fmt.Sprintf("getting content for path %s", path))
 		return

--- a/pkg/githubInfo.go
+++ b/pkg/githubInfo.go
@@ -1,11 +1,15 @@
 package pkg
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/gofri/go-github-ratelimit/github_ratelimit"
 	"github.com/pkg/errors"
 )
 
@@ -13,7 +17,10 @@ func GetGitHubAPI(path string) (*http.Response, error) {
 	token := os.Getenv("GITHUB_TOKEN")
 	url := fmt.Sprintf("https://api.github.com%s", path)
 
-	client := &http.Client{}
+	client, err := github_ratelimit.NewRateLimitWaiterClient(nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating GitHub rate limiter client")
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
@@ -51,4 +58,94 @@ type GitHubCommit struct {
 			Date  time.Time `json:"date"`
 		} `json:"author"`
 	} `json:"commit"`
+}
+
+type RepositoryContent struct {
+	Type *string `json:"type,omitempty"`
+	// Target is only set if the type is "symlink" and the target is not a normal file.
+	// If Target is set, Path will be the symlink path.
+	Target   *string `json:"target,omitempty"`
+	Encoding *string `json:"encoding,omitempty"`
+	Size     *int    `json:"size,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Path     *string `json:"path,omitempty"`
+	// Content contains the actual file content, which may be encoded.
+	// Callers should call GetContent which will decode the content if
+	// necessary.
+	Content         *string `json:"content,omitempty"`
+	SHA             *string `json:"sha,omitempty"`
+	URL             *string `json:"url,omitempty"`
+	GitURL          *string `json:"git_url,omitempty"`
+	HTMLURL         *string `json:"html_url,omitempty"`
+	DownloadURL     *string `json:"download_url,omitempty"`
+	SubmoduleGitURL *string `json:"submodule_git_url,omitempty"`
+}
+
+func GetGitHubFileContents(repoSlug, repoPath, version string) (result *[]RepositoryContent, err error) {
+	path := fmt.Sprintf("/repos/%s/contents/%s", repoSlug, repoPath)
+	if version != "" {
+		path += fmt.Sprintf("?ref=%s", version)
+	}
+	return getGitHubFileContents(path)
+}
+
+func getGitHubFileContents(path string) (result *[]RepositoryContent, err error) {
+	rawJSON, err := GetGitHubAPI(path)
+	if err != nil {
+		err = errors.Wrap(err, fmt.Sprintf("getting content for path %s", path))
+		return
+	}
+	defer rawJSON.Body.Close()
+	if rawJSON.StatusCode != 200 {
+		err = fmt.Errorf("getting content for path %s failed with HTTP %d", path, rawJSON.StatusCode)
+		return
+	}
+
+	var content []RepositoryContent
+	err = json.NewDecoder(rawJSON.Body).Decode(&content)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("getting content for path %s", path))
+	}
+
+	fileResult := []RepositoryContent{}
+	for _, c := range content {
+		if strings.EqualFold(*c.Type, "dir") {
+			r, err := getGitHubFileContents(*c.URL)
+			if err != nil {
+				return nil, err
+			}
+			fileResult = append(fileResult, (*r)...)
+		} else {
+			fileResult = append(fileResult, c)
+		}
+	}
+
+	result = &fileResult
+	return
+}
+
+func GetGitHubTags(repoSlug string) ([]GitHubTag, error) {
+	path := fmt.Sprintf("/repos/%s/tags", repoSlug)
+	tagsResp, err := GetGitHubAPI(path)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("getting tags info for %s", repoSlug))
+	}
+	defer tagsResp.Body.Close()
+
+	if tagsResp.StatusCode != 200 {
+		respBody, err := io.ReadAll(tagsResp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("getting tags info for %s: %s", repoSlug, tagsResp.Status))
+		}
+
+		return nil, fmt.Errorf("getting tags info for %s: %s", repoSlug, string(respBody))
+	}
+
+	var tags []GitHubTag
+	err = json.NewDecoder(tagsResp.Body).Decode(&tags)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("constructing tags information for %s", repoSlug))
+	}
+
+	return tags, nil
 }


### PR DESCRIPTION
This PR will change the `PackageMetadataCmd` so that all files stored in the docs folder of a provider repository is copied.

Closes: https://github.com/pulumi/registry/issues/3159

Because `registrygen` is now handling GitHub rate limits, I think the following code from the `generate-package-metadata.yml` GitHub workflow in the Pulumi Registry repo can be removed.

![image](https://github.com/pulumi/registrygen/assets/14177833/4e1558cb-b8cd-4813-a967-d339407e8a50)

https://github.com/pulumi/registry/blob/096f5e85b01cb436a57c47c186b20e60513f0627/.github/workflows/generate-package-metadata.yml#L55
